### PR TITLE
Added ability to open admin portal from the app.

### DIFF
--- a/FronteggIonicCapacitor.podspec
+++ b/FronteggIonicCapacitor.podspec
@@ -13,7 +13,7 @@ Pod::Spec.new do |s|
   s.source_files = 'ios/Plugin/**/*.{swift,h,m,c,cc,mm,cpp}'
   s.ios.deployment_target  = '14.0'
   s.dependency 'Capacitor'
-  s.dependency "FronteggSwift", "1.2.76"
+  s.dependency "FronteggSwift", "1.3.10"
   s.swift_version = '5.1'
   s.pod_target_xcconfig = {
     'CODE_SIGNING_ALLOWED' => 'YES'

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -62,7 +62,7 @@ dependencies {
     implementation "androidx.browser:browser:1.8.0"
     implementation 'io.reactivex.rxjava3:rxkotlin:3.0.1'
     implementation 'com.google.code.gson:gson:2.10'
-    implementation 'com.frontegg.sdk:android:1.3.18'
+    implementation 'com.frontegg.sdk:android:1.3.34'
 
     testImplementation "junit:junit:$junitVersion"
     androidTestImplementation "androidx.test.ext:junit:$androidxJunitVersion"

--- a/android/src/main/java/com/frontegg/ionic/FronteggNativePlugin.java
+++ b/android/src/main/java/com/frontegg/ionic/FronteggNativePlugin.java
@@ -8,6 +8,7 @@ import android.util.Log;
 
 import kotlin.Unit;
 
+import com.frontegg.android.AdminPortalActivity;
 import com.frontegg.android.FronteggApp;
 import com.frontegg.android.FronteggAppKt;
 import com.frontegg.android.FronteggAuth;
@@ -320,6 +321,17 @@ public class FronteggNativePlugin extends Plugin {
         resultMap.put("regionData", Parser.regionsToJSONObject(regionsData));
 
         call.resolve(resultMap);
+    }
+
+    @PluginMethod
+    public void openAdminPortal(PluginCall call) {
+        if (this.getActivity() == null) {
+            call.reject("NO_ACTIVITY", "Cannot open Admin Portal without an active Activity");
+            return;
+        }
+
+        AdminPortalActivity.open(this.getActivity());
+        call.resolve();
     }
 
 }

--- a/docs/README.md
+++ b/docs/README.md
@@ -22,6 +22,28 @@ For full documentation, visit the Frontegg Developer Portal:
 
 ---
 
+## 🔐 Native SDK versions
+
+The Ionic Capacitor wrapper depends on the underlying native SDKs:
+
+- On **Android**, the plugin and example app use `com.frontegg.sdk:android:1.3.34`.
+- On **iOS**, the plugin depends on `FronteggSwift` **1.3.10** via CocoaPods.
+
+After upgrading, run `pod install` in your iOS project and rebuild both platforms.
+
+---
+
+## 🔐 Native SDK versions
+
+The Ionic Capacitor wrapper depends on the underlying native SDKs:
+
+- On **Android**, the plugin and example app use `com.frontegg.sdk:android:1.3.34`.
+- On **iOS**, the plugin depends on `FronteggSwift` **1.3.10** via CocoaPods.
+
+After upgrading, run `pod install` in your iOS project and rebuild both platforms.
+
+---
+
 ## 🧑‍💻 Getting Started with Frontegg
 
 Don't have a Frontegg account yet?  

--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -3,3 +3,4 @@
 - [Setup Guide](setup.md)
 - [Usage Examples](usage.md)
 - [Advanced Topics](advanced.md)
+- [API Reference](api.md)

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -244,4 +244,25 @@ export default config;
 
 If your app supports multiple environments or regions, define `applicationId` inside each region object:
 
+## Admin Portal (Beta)
+
+The Admin Portal is a hosted page that lets end users manage their account, profile, sessions, and tenant settings. The Ionic Capacitor SDK exposes `openAdminPortal()` on `FronteggService`, which delegates to the native SDKs:
+
+- **Android** — launches `AdminPortalActivity` (full-screen `WebView`)
+- **iOS** — presents `AdminPortalView` as a page sheet (`WKWebView`)
+
+The portal loads `${baseUrl}/oauth/portal?appId=<applicationId>` and shares the SDK session, so authenticated users are not asked to sign in again.
+
+> **Beta.** The API may change in future minor releases. Pin to an exact SDK version when embedding this in a shipping app.
+
+### Multi-app prerequisite
+
+For multi-app workspaces, configure `applicationId` in your native setup (see [Multi-apps support](#multi-apps-support)). Without `?appId=` the portal renders **"Application not found"** after sign-in.
+
+### Open the portal
+
+```typescript
+await this.fronteggService.openAdminPortal();
 ```
+
+The portal is dismissed when the user swipes down (iOS) or taps the built-in close button. On Android, `window.close()` finishes the activity automatically.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -287,3 +287,13 @@ export class MyPage implements OnInit {
   }
 }
 ```
+
+## Admin Portal (Beta)
+
+Open the embedded Frontegg Admin Portal for authenticated users:
+
+```typescript
+await this.fronteggService.openAdminPortal();
+```
+
+See [Advanced Topics](advanced.md#admin-portal-beta) for prerequisites and platform behavior.

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -62,7 +62,7 @@ dependencies {
 
   implementation project(':capacitor-android')
   implementation project(':capacitor-cordova-android-plugins')
-  implementation 'com.frontegg.sdk:android:1.3.18'
+  implementation 'com.frontegg.sdk:android:1.3.34'
 
   testImplementation "junit:junit:$junitVersion"
   androidTestImplementation "androidx.test.ext:junit:$androidxJunitVersion"

--- a/example/ios/App/Podfile
+++ b/example/ios/App/Podfile
@@ -19,8 +19,7 @@ def capacitor_pods
 end
 
 target 'App' do
-  # Resolve FronteggSwift from git (1.2.76 not on CocoaPods trunk yet); must be before FronteggIonicCapacitor
-  pod 'FronteggSwift', :git => 'https://github.com/frontegg/frontegg-ios-swift.git', :tag => '1.2.76'
+  pod 'FronteggSwift', '1.3.10'
   capacitor_pods
   # Add your Pods here
 end

--- a/example/src/app/tab1/tab1.page.html
+++ b/example/src/app/tab1/tab1.page.html
@@ -38,4 +38,10 @@
     <br/>
     <br/>
     <ion-button *ngIf="isAuthenticated" (click)="refreshToken()">Refresh Token</ion-button>
+
+    <br/>
+    <br/>
+    <ion-button *ngIf="isAuthenticated" (click)="openAdminPortal()" aria-label="OpenAdminPortalButton">
+        Open Admin Portal
+    </ion-button>
 </ion-content>

--- a/example/src/app/tab1/tab1.page.ts
+++ b/example/src/app/tab1/tab1.page.ts
@@ -65,4 +65,11 @@ export class Tab1Page implements OnInit {
     console.log('refreshToken()');
     this.fronteggService.refreshToken()
   }
+
+  openAdminPortal() {
+    console.log('openAdminPortal()');
+    this.fronteggService.openAdminPortal().catch((error) => {
+      console.error('Failed to open Admin Portal:', error);
+    });
+  }
 }

--- a/ios/Plugin/FronteggNativePlugin.m
+++ b/ios/Plugin/FronteggNativePlugin.m
@@ -12,6 +12,7 @@ CAP_PLUGIN(FronteggNativePlugin, "FronteggNative",
            CAP_PLUGIN_METHOD(refreshToken, CAPPluginReturnPromise);
            CAP_PLUGIN_METHOD(initWithRegion, CAPPluginReturnPromise);
            CAP_PLUGIN_METHOD(directLoginAction, CAPPluginReturnPromise);
+           CAP_PLUGIN_METHOD(openAdminPortal, CAPPluginReturnPromise);
 )
 
 

--- a/ios/Plugin/FronteggNativePlugin.swift
+++ b/ios/Plugin/FronteggNativePlugin.swift
@@ -2,6 +2,8 @@ import FronteggSwift
 import Foundation
 import Combine
 import Capacitor
+import SwiftUI
+import UIKit
 
 /**
  * Please read the Capacitor iOS Plugin Development Guide
@@ -271,6 +273,37 @@ public class FronteggNativePlugin: CAPPlugin {
             "selectedRegion": regionToJson(auth.selectedRegion)
         ]
         call.resolve(body as [String: Any] )
+    }
+
+    @objc func openAdminPortal(_ call: CAPPluginCall) {
+        DispatchQueue.main.async {
+            guard let viewController = Self.topViewController() else {
+                call.reject("NO_VIEW_CONTROLLER", "Cannot open Admin Portal without an active view controller")
+                return
+            }
+
+            if #available(iOS 14.0, *) {
+                let host = UIHostingController(rootView: AdminPortalView())
+                host.modalPresentationStyle = .pageSheet
+                viewController.present(host, animated: true)
+                call.resolve()
+            } else {
+                call.reject("UNSUPPORTED", "Admin Portal requires iOS 14+")
+            }
+        }
+    }
+
+    private static func topViewController() -> UIViewController? {
+        let keyWindow = UIApplication.shared.connectedScenes
+            .compactMap { $0 as? UIWindowScene }
+            .flatMap { $0.windows }
+            .first { $0.isKeyWindow }
+
+        var topController = keyWindow?.rootViewController
+        while let presented = topController?.presentedViewController {
+            topController = presented
+        }
+        return topController
     }
 
 }

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -5,7 +5,7 @@ def capacitor_pods
   use_frameworks!
   pod 'Capacitor', :path => '../node_modules/@capacitor/ios'
   pod 'CapacitorCordova', :path => '../node_modules/@capacitor/ios'
-  pod 'FronteggSwift', "1.2.76"
+  pod 'FronteggSwift', "1.3.10"
 end
 
 target 'Plugin' do

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -192,6 +192,12 @@ export interface FronteggNativePlugin {
    * @returns A promise that resolves when the token refresh is completed.
    */
   refreshToken(): Promise<void>;
+
+  /**
+   * Opens the embedded Frontegg Admin Portal in a native WebView.
+   * @returns A promise that resolves when the portal is presented.
+   */
+  openAdminPortal(): Promise<void>;
 }
 
 /**

--- a/src/frontegg.service.ts
+++ b/src/frontegg.service.ts
@@ -289,4 +289,8 @@ export class FronteggService {
   public refreshToken(): Promise<void> {
     return FronteggNative.refreshToken();
   }
+
+  public openAdminPortal(): Promise<void> {
+    return FronteggNative.openAdminPortal();
+  }
 }

--- a/src/web.ts
+++ b/src/web.ts
@@ -57,4 +57,8 @@ export class FronteggNativeWeb
   async refreshToken(): Promise<void> {
     throw Error(`FronteggNative.refreshToken not implemented in web`);
   }
+
+  async openAdminPortal(): Promise<void> {
+    throw Error('FronteggNative.openAdminPortal not implemented in web');
+  }
 }


### PR DESCRIPTION
Bump frontegg-android-kotlin SDK to 1.3.34.
Bump frontegg-ios-swift SDK to 1.3.10.
Added openAdminPortal() API to open the embedded Admin Portal. Added "Open Admin Portal" button to all demo apps.