### PR TITLE
FR-24939 - chore(deps): bump native SDKs to Android 1.3.35 / iOS 1.3.11

### DIFF
--- a/FronteggIonicCapacitor.podspec
+++ b/FronteggIonicCapacitor.podspec
@@ -13,7 +13,7 @@ Pod::Spec.new do |s|
   s.source_files = 'ios/Plugin/**/*.{swift,h,m,c,cc,mm,cpp}'
   s.ios.deployment_target  = '14.0'
   s.dependency 'Capacitor'
-  s.dependency "FronteggSwift", "1.3.10"
+  s.dependency "FronteggSwift", "1.3.11"
   s.swift_version = '5.1'
   s.pod_target_xcconfig = {
     'CODE_SIGNING_ALLOWED' => 'YES'

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -62,7 +62,7 @@ dependencies {
     implementation "androidx.browser:browser:1.8.0"
     implementation 'io.reactivex.rxjava3:rxkotlin:3.0.1'
     implementation 'com.google.code.gson:gson:2.10'
-    implementation 'com.frontegg.sdk:android:1.3.34'
+    implementation 'com.frontegg.sdk:android:1.3.35'
 
     testImplementation "junit:junit:$junitVersion"
     androidTestImplementation "androidx.test.ext:junit:$androidxJunitVersion"

--- a/docs/README.md
+++ b/docs/README.md
@@ -35,8 +35,8 @@ The wrapper bridges two native capabilities into your Ionic app:
 
 The Ionic Capacitor wrapper depends on the underlying native SDKs:
 
-- On **Android**, the plugin and example app use `com.frontegg.sdk:android:1.3.34`.
-- On **iOS**, the plugin depends on `FronteggSwift` **1.3.10** via CocoaPods.
+- On **Android**, the plugin and example app use `com.frontegg.sdk:android:1.3.35`.
+- On **iOS**, the plugin depends on `FronteggSwift` **1.3.11** via CocoaPods.
 
 After upgrading, run `pod install` in your iOS project and rebuild both platforms.
 

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -62,7 +62,7 @@ dependencies {
 
   implementation project(':capacitor-android')
   implementation project(':capacitor-cordova-android-plugins')
-  implementation 'com.frontegg.sdk:android:1.3.34'
+  implementation 'com.frontegg.sdk:android:1.3.35'
 
   testImplementation "junit:junit:$junitVersion"
   androidTestImplementation "androidx.test.ext:junit:$androidxJunitVersion"

--- a/example/ios/App/Podfile
+++ b/example/ios/App/Podfile
@@ -19,7 +19,7 @@ def capacitor_pods
 end
 
 target 'App' do
-  pod 'FronteggSwift', '1.3.10'
+  pod 'FronteggSwift', '1.3.11'
   capacitor_pods
   # Add your Pods here
 end

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -5,7 +5,7 @@ def capacitor_pods
   use_frameworks!
   pod 'Capacitor', :path => '../node_modules/@capacitor/ios'
   pod 'CapacitorCordova', :path => '../node_modules/@capacitor/ios'
-  pod 'FronteggSwift', "1.3.10"
+  pod 'FronteggSwift', "1.3.11"
 end
 
 target 'Plugin' do


### PR DESCRIPTION
- Bump native SDKs: `frontegg-android-kotlin` **1.3.34 → 1.3.35**, `frontegg-ios-swift` (FronteggSwift) **1.3.10 → 1.3.11**.

What this picks up:

- Fixed: embedded step-up renders the MFA challenge instead of a blank page — the embedded login WebView exposes the native `getTokens` token bridge and a new step-up web driver routes the hosted login box to its step-up page, completing with an elevated (stepped-up) token. Requires hosted login box ≥ 7.118.0. (FR-24939)
- Fixed (iOS): step-up authorize URL emits OIDC-compliant integer `max_age`; connectivity observer stays alive across repeated offline/online cycles. (FR-25783)
- Fixed (Android): token refresh no longer stalls on short-TTL environments (refresh dedup keyed on token identity); deprecated `startActivityForResult` removed. (FR-19725)

All version references bumped: plugin + example app Gradle pins, SPM/CocoaPods manifests, and docs.

> Note: `com.frontegg.sdk:android:1.3.35` was released ~40 min ago and may still be syncing to Maven Central — if the Android CI job fails on dependency resolution, re-run it after sync.
