### PR TITLE
feat: add step-up bridge (stepUp / isSteppedUp)

### DIFF
--- a/android/src/main/java/com/frontegg/ionic/FronteggNativePlugin.java
+++ b/android/src/main/java/com/frontegg/ionic/FronteggNativePlugin.java
@@ -392,4 +392,33 @@ public class FronteggNativePlugin extends Plugin {
         call.resolve();
     }
 
+    @PluginMethod
+    public void isSteppedUp(PluginCall call) {
+        // NOTE: `maxAge` is honored on iOS but not yet forwarded here — the native
+        // isSteppedUp(Duration?) takes a Kotlin Duration (an inline value class) that cannot be
+        // constructed from Java. Passing null checks ACR/AMR without the freshness window until a
+        // native Java-friendly overload is added.
+        boolean result = FronteggAppKt.getFronteggAuth(this.getContext()).isSteppedUp(null);
+        JSObject ret = new JSObject();
+        ret.put("isSteppedUp", result);
+        call.resolve(ret);
+    }
+
+    @PluginMethod
+    public void stepUp(PluginCall call) {
+        if (this.getActivity() == null) {
+            call.reject("NO_ACTIVITY", "Cannot start step-up without an active Activity");
+            return;
+        }
+        // `maxAge` not forwarded on Android — see isSteppedUp note above.
+        FronteggAppKt.getFronteggAuth(this.getContext()).stepUp(this.getActivity(), null, (error) -> {
+            if (error != null) {
+                call.reject(error.getMessage());
+            } else {
+                call.resolve();
+            }
+            return null;
+        });
+    }
+
 }

--- a/ios/Plugin/FronteggNativePlugin.m
+++ b/ios/Plugin/FronteggNativePlugin.m
@@ -16,6 +16,8 @@ CAP_PLUGIN(FronteggNativePlugin, "FronteggNative",
            CAP_PLUGIN_METHOD(getFeatureEntitlement, CAPPluginReturnPromise);
            CAP_PLUGIN_METHOD(getPermissionEntitlement, CAPPluginReturnPromise);
            CAP_PLUGIN_METHOD(openAdminPortal, CAPPluginReturnPromise);
+           CAP_PLUGIN_METHOD(stepUp, CAPPluginReturnPromise);
+           CAP_PLUGIN_METHOD(isSteppedUp, CAPPluginReturnPromise);
 )
 
 

--- a/ios/Plugin/FronteggNativePlugin.swift
+++ b/ios/Plugin/FronteggNativePlugin.swift
@@ -324,6 +324,27 @@ public class FronteggNativePlugin: CAPPlugin {
         }
     }
 
+    @objc func isSteppedUp(_ call: CAPPluginCall) {
+        // `maxAge` is optional and expressed in seconds (TimeInterval); nil uses the SDK default.
+        let maxAge = call.getDouble("maxAge")
+        call.resolve(["isSteppedUp": fronteggApp.auth.isSteppedUp(maxAge: maxAge)])
+    }
+
+    @objc func stepUp(_ call: CAPPluginCall) {
+        let maxAge = call.getDouble("maxAge")
+        let completion: FronteggAuth.CompletionHandler = { result in
+            switch result {
+            case .success:
+                call.resolve()
+            case .failure(let error):
+                call.reject(error.failureReason ?? error.localizedDescription, nil, error)
+            }
+        }
+        Task {
+            await self.fronteggApp.auth.stepUp(maxAge: maxAge, completion)
+        }
+    }
+
     private static func topViewController() -> UIViewController? {
         let keyWindow = UIApplication.shared.connectedScenes
             .compactMap { $0 as? UIWindowScene }

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -222,6 +222,27 @@ export interface FronteggNativePlugin {
    * @returns A promise that resolves when the portal is presented.
    */
   openAdminPortal(): Promise<void>;
+
+  /**
+   * Starts a step-up (re-)authentication: the user re-verifies with a stronger factor
+   * (MFA) before a sensitive action. Resolves once step-up completes (rejects on failure).
+   *
+   * @param payload.maxAge - Optional freshness window, in **seconds**. If the user
+   * authenticated more recently than this, step-up may be skipped.
+   *
+   * Note: `maxAge` is honored on **iOS**. On **Android** it is not yet forwarded (the native
+   * API takes a Kotlin `Duration` that cannot be constructed from the Java plugin); Android
+   * uses the server default freshness window until a native Java-friendly overload lands.
+   */
+  stepUp(payload?: { maxAge?: number }): Promise<void>;
+
+  /**
+   * Returns whether the current session is already "stepped up" (has a recent MFA/ACR).
+   *
+   * @param payload.maxAge - Optional freshness window, in **seconds** (see `stepUp` for the
+   * Android `maxAge` caveat).
+   */
+  isSteppedUp(payload?: { maxAge?: number }): Promise<{ isSteppedUp: boolean }>;
 }
 
 /**

--- a/src/frontegg.service.ts
+++ b/src/frontegg.service.ts
@@ -316,4 +316,22 @@ export class FronteggService {
   public openAdminPortal(): Promise<void> {
     return FronteggNative.openAdminPortal();
   }
+
+  /**
+   * Start a step-up (re-)authentication. Resolves when step-up completes.
+   * @param maxAge Optional freshness window in seconds (honored on iOS; see docs for the
+   * Android caveat).
+   */
+  public stepUp(maxAge?: number): Promise<void> {
+    return FronteggNative.stepUp({ maxAge });
+  }
+
+  /**
+   * Whether the current session is already stepped up.
+   * @param maxAge Optional freshness window in seconds.
+   */
+  public async isSteppedUp(maxAge?: number): Promise<boolean> {
+    const { isSteppedUp } = await FronteggNative.isSteppedUp({ maxAge });
+    return isSteppedUp;
+  }
 }

--- a/src/web.ts
+++ b/src/web.ts
@@ -86,4 +86,20 @@ export class FronteggNativeWeb
   async openAdminPortal(): Promise<void> {
     throw Error('FronteggNative.openAdminPortal not implemented in web');
   }
+
+  async stepUp(payload?: { maxAge?: number }): Promise<void> {
+    throw Error(
+      `FronteggNative.stepUp ${JSON.stringify(payload)} not implemented in web`,
+    );
+  }
+
+  async isSteppedUp(payload?: {
+    maxAge?: number;
+  }): Promise<{ isSteppedUp: boolean }> {
+    throw Error(
+      `FronteggNative.isSteppedUp ${JSON.stringify(
+        payload,
+      )} not implemented in web`,
+    );
+  }
 }


### PR DESCRIPTION
## Summary

Exposes the native **step-up (re-)authentication** API through the Ionic Capacitor plugin, bringing it to parity with the React Native and Flutter wrappers. Step-up lets the app force a fresh, stronger factor (MFA) before a sensitive action.

Two methods are added across all layers:

- `stepUp(payload?: { maxAge?: number }): Promise<void>` — starts step-up; resolves on success, rejects on failure.
- `isSteppedUp(payload?: { maxAge?: number }): Promise<{ isSteppedUp: boolean }>` — whether the session already satisfies the step-up requirement.

`maxAge` is an optional freshness window in **seconds**.

## Changes

| Layer | File | What |
|-------|------|------|
| TS API | `src/definitions.ts` | `stepUp` / `isSteppedUp` on the plugin interface |
| TS web | `src/web.ts` | web stubs (throw "not implemented in web", matching the other methods) |
| TS service | `src/frontegg.service.ts` | `FronteggService.stepUp(maxAge?)` / `isSteppedUp(maxAge?)` convenience wrappers |
| iOS | `ios/Plugin/FronteggNativePlugin.swift` | async bridge to `auth.stepUp` / `auth.isSteppedUp`, honoring `maxAge` |
| iOS | `ios/Plugin/FronteggNativePlugin.m` | `CAP_PLUGIN_METHOD` registrations |
| Android | `android/.../FronteggNativePlugin.java` | `@PluginMethod` bridges to the native SDK |

## Platform note on `maxAge`

`maxAge` is **honored on iOS**. On **Android** it is not yet forwarded: the native `stepUp(activity, Duration?, …)` / `isSteppedUp(Duration?)` take a Kotlin `Duration` (an inline value class) that cannot be constructed from this Java plugin. Android therefore uses the server default freshness window until a native Java-friendly overload is added. This mirrors the accepted trade-off used elsewhere in the wrappers and is documented in the TS JSDoc.

## Testing

- `npm run build` — passes (tsc + rollup).
- `npm run lint` — passes (eslint + prettier over ts/js/**java**).

Native Android/iOS are not compiled in this repo's CI (JS package only), so the native bridges were verified by mirroring the already-shipped React Native step-up bridge signatures against the released native SDKs (iOS FronteggSwift 1.3.11, Android 1.3.35, both on `origin/master` via #85).
