### PR TITLE
chore(deps): bump native SDKs to Android 1.3.36 / iOS 1.3.12

### DIFF
--- a/FronteggIonicCapacitor.podspec
+++ b/FronteggIonicCapacitor.podspec
@@ -13,7 +13,7 @@ Pod::Spec.new do |s|
   s.source_files = 'ios/Plugin/**/*.{swift,h,m,c,cc,mm,cpp}'
   s.ios.deployment_target  = '14.0'
   s.dependency 'Capacitor'
-  s.dependency "FronteggSwift", "1.3.11"
+  s.dependency "FronteggSwift", "1.3.12"
   s.swift_version = '5.1'
   s.pod_target_xcconfig = {
     'CODE_SIGNING_ALLOWED' => 'YES'

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -62,7 +62,7 @@ dependencies {
     implementation "androidx.browser:browser:1.8.0"
     implementation 'io.reactivex.rxjava3:rxkotlin:3.0.1'
     implementation 'com.google.code.gson:gson:2.10'
-    implementation 'com.frontegg.sdk:android:1.3.35'
+    implementation 'com.frontegg.sdk:android:1.3.36'
 
     testImplementation "junit:junit:$junitVersion"
     androidTestImplementation "androidx.test.ext:junit:$androidxJunitVersion"


### PR DESCRIPTION
Bumps the bundled native SDK versions so the Capacitor/Ionic wrapper picks up the July 2026 mobile-SDK audit fixes:

- **Android** `com.frontegg.sdk:android` 1.3.35 → **1.3.36**
- **iOS** `FronteggSwift` 1.3.11 → **1.3.12**

No wrapper API changes.