### PR TITLE
fix(capacitor): resolve initWithRegion on iOS so the promise no longer hangs (FR-25945)

### DIFF
--- a/ios/Plugin/FronteggNativePlugin.swift
+++ b/ios/Plugin/FronteggNativePlugin.swift
@@ -238,6 +238,9 @@ public class FronteggNativePlugin: CAPPlugin {
         }
 
         fronteggApp.initWithRegion(regionKey: regionKey)
+        // FR-25945: the JS promise from initWithRegion hung forever on iOS because we never
+        // resolved the call (Android already resolves). Resolve so await-based region flows proceed.
+        call.resolve()
     }
 
     @objc func refreshToken(_ call: CAPPluginCall) {


### PR DESCRIPTION
## FR-25945 — iOS `initWithRegion` never resolves (promise hangs)

`ios/Plugin/FronteggNativePlugin.swift` `initWithRegion()` called `fronteggApp.initWithRegion(...)` but never called `call.resolve()`, so the JS promise from `FronteggService.initWithRegion` hung forever on iOS. Android already resolves. Any `await`-based region-selection flow (e.g. the example's `region.guard.ts`) stalled.

## Fix
Call `call.resolve()` after `initWithRegion` on iOS.

## Note
iOS-only; verified via `swiftc -parse`. Not compiled in a full iOS build here (no iOS build harness) — please let CI confirm.