### PR TITLE
fix(capacitor): don't log out on Android refresh failure; resolve {success} (FR-25946)

### DIFF
--- a/android/src/main/java/com/frontegg/ionic/FronteggNativePlugin.java
+++ b/android/src/main/java/com/frontegg/ionic/FronteggNativePlugin.java
@@ -286,14 +286,13 @@ public class FronteggNativePlugin extends Plugin {
         executor.submit(() -> {
             Handler handler = new Handler(Looper.getMainLooper());
             FronteggAuth fronteggAuth = FronteggAppKt.getFronteggAuth(this.getContext());
-            if (!fronteggAuth.refreshTokenIfNeeded()) {
-                fronteggAuth.logout(() -> {
-                    handler.post(call::resolve);
-                    return null;
-                });
-            } else {
-                handler.post(call::resolve);
-            }
+            // FR-25946: previously a failed refresh (e.g. a transient network blip during an
+            // app-initiated refreshToken()) logged the user out — destructive and divergent from
+            // iOS. Resolve { success } instead and leave the session intact, matching iOS.
+            boolean success = fronteggAuth.refreshTokenIfNeeded();
+            JSObject result = new JSObject();
+            result.put("success", success);
+            handler.post(() -> call.resolve(result));
         });
     }
 


### PR DESCRIPTION
## FR-25946 — Android `refreshToken()` logs the user out on any refresh failure

`android/.../FronteggNativePlugin.java` `refreshToken()` did `if (!refreshTokenIfNeeded()) { logout(...) }`. A momentary connectivity blip during a manual `refreshToken()` therefore **destroyed the session** — undocumented, destructive, and platform-divergent (iOS just resolves `{success:false}`).

## Fix
Resolve `{ success }` and leave the session intact, matching iOS. No logout on refresh failure.

## Note
Android/Java; not unit-testable in isolation (final `fronteggAuth` singleton, no unit-test harness in this repo). Reviewed against the iOS `refreshToken` behavior — please let CI/an Android build confirm.