### PR TITLE
fix(capacitor): propagate login/directLogin/switchTenant errors; awaitable logout (FR-25947)

### DIFF
--- a/android/src/main/java/com/frontegg/ionic/FronteggNativePlugin.java
+++ b/android/src/main/java/com/frontegg/ionic/FronteggNativePlugin.java
@@ -220,7 +220,13 @@ public class FronteggNativePlugin extends Plugin {
     public void login(PluginCall call) {
         String loginHint = call.getString("loginHint");
         FronteggAppKt.getFronteggAuth(this.getContext()).login(this.getActivity(), loginHint != null ? loginHint : "", null, (Exception e) -> {
-            call.resolve();
+            // FR-25947: previously ignored the Exception and always resolved, so a cancelled/failed
+            // login looked like success. Reject on error.
+            if (e != null) {
+                call.reject(e.getMessage() != null ? e.getMessage() : "Login failed", e);
+            } else {
+                call.resolve();
+            }
             return Unit.INSTANCE;
         });
     }
@@ -235,7 +241,12 @@ public class FronteggNativePlugin extends Plugin {
             return;
         }
         FronteggAppKt.getFronteggAuth(this.getContext()).directLoginAction(this.getActivity(), type, data, (Exception e) -> {
-            call.resolve();
+            // FR-25947: reject on error instead of always resolving.
+            if (e != null) {
+                call.reject(e.getMessage() != null ? e.getMessage() : "Direct login failed", e);
+            } else {
+                call.resolve();
+            }
             return Unit.INSTANCE;
         });
     }

--- a/ios/Plugin/FronteggNativePlugin.swift
+++ b/ios/Plugin/FronteggNativePlugin.swift
@@ -185,11 +185,18 @@ public class FronteggNativePlugin: CAPPlugin {
     @objc func login(_ call: CAPPluginCall) {
         let loginHint = call.options["loginHint"] as? String
         DispatchQueue.main.sync {
-            fronteggApp.auth.login({ _ in
-                call.resolve()
+            // FR-25947: previously `{ _ in call.resolve() }` swallowed the result, so a
+            // cancelled/failed login resolved as success. Reject on failure.
+            fronteggApp.auth.login({ result in
+                switch result {
+                case .success(_):
+                    call.resolve()
+                case .failure(let error):
+                    call.reject(error.failureReason ?? error.localizedDescription, nil, error)
+                }
             }, loginHint: loginHint)
         }
-        
+
     }
 
 
@@ -206,18 +213,27 @@ public class FronteggNativePlugin: CAPPlugin {
         let ephemeralSession = call.getBool("ephemeralSession", true)
 
         DispatchQueue.main.sync {
-            fronteggApp.auth.directLoginAction(window: nil, type: type, data: data, ephemeralSession: ephemeralSession) { _ in
-                call.resolve()
+            // FR-25947: reject on failure instead of always resolving.
+            fronteggApp.auth.directLoginAction(window: nil, type: type, data: data, ephemeralSession: ephemeralSession) { result in
+                switch result {
+                case .success(_):
+                    call.resolve()
+                case .failure(let error):
+                    call.reject(error.failureReason ?? error.localizedDescription, nil, error)
+                }
             }
         }
 
     }
 
     @objc func logout(_ call: CAPPluginCall) {
+        // FR-25947: logout previously resolved immediately without waiting for the SDK. Pass the
+        // completion and resolve when it finishes, so JS callers can await logout before navigating.
         DispatchQueue.main.sync {
-            fronteggApp.auth.logout()
+            fronteggApp.auth.logout { _ in
+                call.resolve()
+            }
         }
-        call.resolve()
     }
 
     @objc func switchTenant(_ call: CAPPluginCall) {
@@ -226,8 +242,14 @@ public class FronteggNativePlugin: CAPPlugin {
             return
         }
 
-        fronteggApp.auth.switchTenant(tenantId: tenantId) { _ in
-            call.resolve()
+        // FR-25947: reject on failure instead of always resolving.
+        fronteggApp.auth.switchTenant(tenantId: tenantId) { result in
+            switch result {
+            case .success(_):
+                call.resolve()
+            case .failure(let error):
+                call.reject(error.failureReason ?? error.localizedDescription, nil, error)
+            }
         }
     }
 

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -166,10 +166,10 @@ export interface FronteggNativePlugin {
   }): Promise<boolean>;
 
   /**
-   * Logs out the current user.
-   * This method does not return a promise, and the logout process is performed asynchronously.
+   * Logs out the current user. Resolves once the native logout completes, so callers can
+   * `await logout()` before navigating.
    */
-  logout(): void;
+  logout(): Promise<void>;
 
   /**
    * Switches the current tenant in the application.

--- a/src/frontegg.service.ts
+++ b/src/frontegg.service.ts
@@ -261,8 +261,8 @@ export class FronteggService {
     return FronteggNative.directLoginAction({ type, data, ephemeralSession });
   }
 
-  public logout(): void {
-    FronteggNative.logout();
+  public logout(): Promise<void> {
+    return FronteggNative.logout();
   }
 
   public getConstants(): Promise<FronteggConstants> {


### PR DESCRIPTION
## FR-25947 — native errors swallowed on login/directLogin/switchTenant; logout has no completion

(The newer stepUp bridge and Android `switchTenant` already propagate errors; this covers the remaining swallowing sites.)

- **iOS**: `login` (~188), `directLoginAction` (~209), `switchTenant` (~229) used `{ _ in call.resolve() }` — they now `switch` on the `Result` and `call.reject(error.failureReason ?? error.localizedDescription, nil, error)` on failure (matching `stepUp`). `logout` previously resolved immediately without waiting; it now passes the SDK completion and resolves inside it.
- **Android**: `login` (~222) and `directLoginAction` (~237) ignored the `Exception e` callback arg — now `reject` on a non-null error.
- **JS**: `FronteggNativePlugin.logout()` typed `void` → `Promise<void>` (`web.ts` already returned a promise); `frontegg.service.logout()` now `return`s it so callers can `await logout()` before navigation.

## Failure scenario fixed
JS callers can now distinguish success from failure/cancel, and can `await logout()` before navigating.

## Verification
iOS via `swiftc -parse`; TS via `tsc --noEmit` (clean). Android/Java reviewed (no unit-test harness in this repo). Please let CI / device builds confirm the native halves.