### PR TITLE
fix(capacitor): don't hard-kill the app on load() config errors (FR-25948)

### DIFF
--- a/android/src/main/java/com/frontegg/ionic/FronteggNativePlugin.java
+++ b/android/src/main/java/com/frontegg/ionic/FronteggNativePlugin.java
@@ -84,7 +84,10 @@ public class FronteggNativePlugin extends Plugin {
             }
 
         } catch (JSONException e) {
-            throw new RuntimeException(e);
+            // FR-25948: don't throw — a RuntimeException here hard-kills the app on a config error.
+            // Log and abort initialization; JS calls surface the error instead of a crash.
+            Log.e("FronteggNative", "Failed to parse Frontegg regions config", e);
+            return;
         }
 
         Class<?> mainActivityClass = resolveMainActivityClass();
@@ -114,7 +117,9 @@ public class FronteggNativePlugin extends Plugin {
             }
 
             if (baseUrl == null || clientId == null) {
-                throw new RuntimeException("Missing required config parameters: baseUrl, clientId");
+                // FR-25948: don't throw — log and abort initialization instead of crashing the app.
+                Log.e("FronteggNative", "Missing required config parameters: baseUrl, clientId");
+                return;
             }
             if (baseUrl.startsWith("https://")) {
                 baseUrl = baseUrl.substring(baseUrl.indexOf("://") + 3);

--- a/ios/Plugin/FronteggNativePlugin.swift
+++ b/ios/Plugin/FronteggNativePlugin.swift
@@ -49,8 +49,10 @@ public class FronteggNativePlugin: CAPPlugin {
             }
 
             if(regions.isEmpty){
+                // FR-25948: don't exit(1) — hard-killing the app on misconfiguration is worse than
+                // leaving the plugin uninitialized. Log and return; JS calls surface the error.
                 print("Frontegg Error: Missing regions configurations")
-                exit(1)
+                return
             }
             fronteggApp.manualInitRegions(regions: regions,
                                           handleLoginWithSocialLogin: handleLoginWithSocialLogin,
@@ -76,8 +78,9 @@ public class FronteggNativePlugin: CAPPlugin {
                                        handleLoginWithSocialLogin: handleLoginWithSocialLogin,
                                        handleLoginWithSSO: handleLoginWithSSO)
             }else {
+                // FR-25948: don't exit(1) — log and return instead of terminating the process.
                 print("Frontegg Error: Missing baseUrl or clientId in project configurations")
-                exit(1)
+                return
             }
         }
 


### PR DESCRIPTION
## FR-25948 — `load()` hard-kills the app on config errors

On missing/invalid config, `load()` terminated the process: iOS called `exit(1)` (`FronteggNativePlugin.swift` ~53, ~80), Android threw `RuntimeException` (~87, ~117). Both crash the app instead of surfacing a recoverable error.

## Fix
`load()` is a Capacitor lifecycle method with no `CAPPluginCall`/`PluginCall` to reject, so it can't return a rejected promise directly. Instead of terminating the process, both platforms now **log the misconfiguration and return early** (abort initialization). The app stays alive; subsequent JS calls surface the error rather than a hard crash.

## Note
iOS via `swiftc -parse`; Android/Java reviewed (no unit-test harness in this repo). Please let CI / device builds confirm.