### PR TITLE
docs: appId in associated-domains registration is the app identifier, not a domain

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -82,11 +82,13 @@ To enable domain-based authentication flows, like magic link, password reset and
 
 ```json
 {
-  "appId": "{{ASSOCIATED_DOMAIN}}"
+  "appId": "{{TEAM_ID}}.{{BUNDLE_ID}}"
 }
 ```
 
-Replace `{{ASSOCIATED_DOMAIN}}` with the domain you want to use (e.g., `example.com`).
+Replace `{{TEAM_ID}}` with your Apple Team ID and `{{BUNDLE_ID}}` with your app's bundle identifier — for example, `ABCDE12345.com.example.app`. You can find your Team ID in the [Apple Developer portal](https://developer.apple.com/account) under **Membership details**, or in Xcode under **Signing & Capabilities**.
+
+> **Warning:** `appId` is your app's identifier, **not** a domain. The API accepts any string without validation, but a domain registered here produces an `apple-app-site-association` entry that iOS silently ignores — Universal Links and passkeys will not work, with no error anywhere.
 
 
 ## Setup Android project


### PR DESCRIPTION
Companion to frontegg/frontegg-ios-swift#314 - full analysis and live-environment evidence there.

The setup guide told readers to register a **domain** in the `appId` field of `POST /vendors/resources/associated-domains/v1/ios`. The field is the Apple app identifier (`{teamId}.{bundleId}`) as published in the `apple-app-site-association` file. The API accepts any string without validation, so a domain registered there produces an AASA entry iOS silently ignores - Universal Links and passkeys fail with no error anywhere.

Corrected the payload to `{{TEAM_ID}}.{{BUNDLE_ID}}` with a concrete example, where to find the Team ID, and a warning about the silent failure.

Docs-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)